### PR TITLE
[WIP]ユーザーログインのエラー表示【修正】

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,8 +1,10 @@
 %h2 Log in
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  = render "devise/shared/error_messages", resource: resource
+  -# = content_tag(:div, flash[:error], :id => "flash_error") if flash[:error]
+  -# = content_tag(:div, flash[:notice], :id => "flash_notice") if flash[:notice]
+  = content_tag(:div, flash[:alert], :id => "flash_alert") if flash[:alert]
+
   .field
-    = f.label :メールアドレス
     %br/
     = f.email_field :email, autofocus: true, autocomplete: "email"
   .field

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,15 @@
 ja:
+  devise:
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントは凍結されています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
   activerecord:
     models:
       user: ユーザー
@@ -17,3 +28,4 @@ ja:
         house_number: 番地
         building_name: マンション・ビル名
         phone_number: 電話番号
+        password: パスワード

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,7 +27,7 @@ describe User do
     it "is invalid without a password_confirmation" do
       user = build(:user, password_confirmation: "")
       user.valid?
-      expect(user.errors[:password_confirmation]).to include("とPasswordの入力が一致しません")
+      expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
     end
 
     it "is invalid without a first_name" do


### PR DESCRIPTION
## What
ユーザーログイン時に、間違った情報を入力したときに、エラーが出るようにする。
## Why
ログイン時に間違った情報を入力した際に、明確にエラーだと分かった方が、ユーザーが使いやすいから