### PR TITLE
新規会員登録の不具合修正

### DIFF
--- a/app/assets/javascripts/address_autofill.js
+++ b/app/assets/javascripts/address_autofill.js
@@ -1,12 +1,13 @@
-$(function() {
-  return $('#user_post_code').jpostal({
-    postcode: ['#user_post_code'],
-    address: {
-      '#user_prefecture_code': '%3',
-      '#user_city': '%4',
-      '#user_house_number': '%5%6%7',
-    },
+$(document).on('turbolinks:load', function(){
+  $(function() {
+    return $('#user_post_code').jpostal({
+      postcode: ['#user_post_code'],
+      address: {
+        '#user_prefecture_code': '%3',
+        '#user_city': '%4',
+        '#user_house_number': '%5%6%7',
+      },
 
+    });
   });
 });
-console.log('test');


### PR DESCRIPTION
## What
　郵便番号を入力すると自動的に住所が入力される機能について、一度リロードしないと機能しない不具合を解消する。
## Why
　この不具合を修正することで、よりスムーズに住所登録ができるため。

